### PR TITLE
Change ordering in initialization of SBUBaseChannel

### DIFF
--- a/uikit/View/Channel/SBUBaseChannelViewController.swift
+++ b/uikit/View/Channel/SBUBaseChannelViewController.swift
@@ -102,10 +102,10 @@ open class SBUBaseChannelViewController: SBUBaseViewController {
         super.init(nibName: nil, bundle: nil)
         SBULog.info("")
         
+        self.customizedMessageListParams = messageListParams
+
         self.baseChannel = baseChannel
         self.channelUrl = baseChannel.channelUrl
-
-        self.customizedMessageListParams = messageListParams
     }
     
     /// If you don't have channel object and have channelUrl, use this initialize function. And, if you have own message list params, please set it. If not set, it is used as the default value.


### PR DESCRIPTION
I was investigating why a sendbird UIKit implementation did not have reactions. It looks like there is a call stack order error

- baseChannel has a didSet
- didSet calls createViewModel,
- createViewModel calls SBUChannelViewModel(... with self.customizedMessageListParams)